### PR TITLE
test: add gist upload testing on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Configure Git
+        shell: bash
         run: |
           git config --global user.name "Tester"
           git config --global user.email "test@example.com"
           if [ -n "$GIST_TESTING_TOKEN" ]; then
-            git config --global url."https://$GIST_TESTING_TOKEN@gist.github.com/".insteadOf "git@gist.github.com:"
+            git config --global credential.https://gist.github.com.username $GIST_TESTING_TOKEN
           fi
         env:
           GIST_TESTING_TOKEN: ${{ secrets.GIST_TESTING_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
+      - name: Configure Git
+        run: |
+          git config --global user.name "Tester"
+          git config --global user.email "test@example.com"
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
         run: |
           git config --global user.name "Tester"
           git config --global user.email "test@example.com"
+          if [ -n "$GIST_TESTING_TOKEN" ]; then
+            git config --global url."https://$GIST_TESTING_TOKEN@gist.github.com/".insteadOf "git@gist.github.com:"
+          fi
+        env:
+          GIST_TESTING_TOKEN: ${{ secrets.GIST_TESTING_TOKEN }}
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
           git config --global user.name "Tester"
           git config --global user.email "test@example.com"
           if [ -n "$GIST_TESTING_TOKEN" ]; then
-            git config --global credential.https://gist.github.com.username $GIST_TESTING_TOKEN
+            git config --global credential.https://gist.github.com.helper store
+            echo "https://julia-artifactutils-bot:$GIST_TESTING_TOKEN@gist.github.com" > ~/.git-credentials
           fi
         env:
           GIST_TESTING_TOKEN: ${{ secrets.GIST_TESTING_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           show-versioninfo: true
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        env:
+          GIST_TESTING_TOKEN: ${{ secrets.GIST_TESTING_TOKEN }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/src/ArtifactUtils.jl
+++ b/src/ArtifactUtils.jl
@@ -156,6 +156,8 @@ add it to `"Artifact.toml"` with the name `"name"`.
 
 ## Keyword Arguments
 - `private`: if `true`, upload the archive to a private gist
+- `ssh`: if `true`, use SSH URL for git operations. This requires the user to have SSH keys
+  set up with GitHub.
 - `name`: name of the archive file, including file extension
 - `extension`: file extension of the tarball. It can be used for specifying the compression
   method.
@@ -167,6 +169,7 @@ function upload_to_gist(
     artifact_id::SHA1,
     tarball::AbstractString;
     private::Bool = true,
+    ssh::Bool = true,
     archive_options...,
 )
     mkpath(dirname(tarball))
@@ -174,7 +177,7 @@ function upload_to_gist(
     sha256 = sha256sum(tarball)
     tarball_size = filesize(tarball)
     iszero(tarball_size) && error("tarball has zero filesize")
-    url = gist_from_file(tarball; private = private)
+    url = gist_from_file(tarball; private = private, ssh = ssh)
     return GistUploadResult(
         artifact_id,
         basename(tarball),

--- a/src/gistutils.jl
+++ b/src/gistutils.jl
@@ -3,11 +3,11 @@
 
 Create a new gist from file at `filepath`. Return the "raw" HTTPS URL of the file.
 """
-function gist_from_file(filepath::AbstractString; private::Bool = true)
+function gist_from_file(filepath::AbstractString; private::Bool = true, ssh::Bool = true)
     @assert isfile(filepath)
     # Using `with_new_gist` utility defined below instead of simply calling `gh gist create
     # $filepath`. This seems to be required when the file at `filepath` is not a text file.
-    repo_http = with_new_gist(; private = private) do git_dir
+    repo_http = with_new_gist(; private = private, ssh = ssh) do git_dir
         cp(filepath, joinpath(git_dir, basename(filepath)))
     end
     return rstrip(repo_http, '/') * "/raw/" * basename(filepath)
@@ -20,7 +20,7 @@ Create a new gist, check it out as a local git repository at a temporary directo
 `git_dir`, call `f(git_dir)`, and then push it to remote.  Return the canonical gist HTTPS
 URL.
 """
-function with_new_gist(f; private::Bool = true)
+function with_new_gist(f; private::Bool = true, ssh::Bool = true)
     cmd = gh_cli_jll.gh()
     cmd = `$cmd gist create`
     if !private
@@ -28,12 +28,16 @@ function with_new_gist(f; private::Bool = true)
     end
     repo_http = chomp(String(communicate(cmd, "dummy")))
 
-    m = match(r"https://gist.github.com/(.*)", repo_http)
-    if m === nothing
-        error("Unrecognized output from `gh cli`: ", repo_http)
+    if ssh
+        m = match(r"https://gist.github.com/(.*)", repo_http)
+        if m === nothing
+            error("Unrecognized output from `gh cli`: ", repo_http)
+        end
+        slug = split(m[1], '/')[2] # remove username
+        git_url = "git@gist.github.com:$slug.git"
+    else
+        git_url = repo_http * ".git"
     end
-    slug = split(m[1], '/')[2] # remove username
-    git_url = "git@gist.github.com:$slug.git"
 
     response = Ref{HTTP.Response}()
     @sync begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,14 +67,12 @@ end
 
 @testset "upload_to_gist" begin
     if haskey(ENV, "GIST_TESTING_TOKEN")
-        run(`git config --global user.email "test@example.com"`)
-        run(`git config --global user.name "tester"`)
         withenv("GH_TOKEN" => ENV["GIST_TESTING_TOKEN"]) do
             mktempdir() do tempdir
                 file = joinpath(tempdir, "hello.txt")
                 write(file, "Hello, world.\n")
                 artifact_id = artifact_from_directory(tempdir)
-                gist = upload_to_gist(artifact_id)
+                gist = upload_to_gist(artifact_id; ssh = false)
 
                 @test gist.id == artifact_id
                 @test occursin("gist.github.com", gist.url)
@@ -117,10 +115,6 @@ end
     mktempdir() do git_dir
         git(args) = run(`$(Git.git()) --no-pager -C $git_dir $args`)
         git(`init`)
-
-        # Setup repository-local user name and email so that it works on CI
-        git(`config user.email "test@example.com"`)
-        git(`config user.name "tester"`)
 
         git(`checkout -b new-branch`)
         write(joinpath(git_dir, "file-1"), "content")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,32 @@ end
     @test occursin("url =", str)
 end
 
+@testset "upload_to_gist" begin
+    if haskey(ENV, "GIST_TESTING_TOKEN")
+        run(`git config --global user.email "test@example.com"`)
+        run(`git config --global user.name "tester"`)
+        withenv("GH_TOKEN" => ENV["GIST_TESTING_TOKEN"]) do
+            mktempdir() do tempdir
+                file = joinpath(tempdir, "hello.txt")
+                write(file, "Hello, world.\n")
+                artifact_id = artifact_from_directory(tempdir)
+                gist = upload_to_gist(artifact_id)
+
+                @test gist.id == artifact_id
+                @test occursin("gist.github.com", gist.url)
+
+                artifact_file = joinpath(tempdir, "Artifacts.toml")
+                add_artifact!(artifact_file, "hello", gist)
+                artifacts = TOML.parsefile(artifact_file)
+                @test haskey(artifacts, "hello")
+                @test artifacts["hello"]["git-tree-sha1"] == string(artifact_id)
+            end
+        end
+    else
+        @info "Skipping `upload_to_gist` tests since `GIST_TESTING_TOKEN` is not set"
+    end
+end
+
 @testset "artifact_from_directory" begin
     mktempdir() do tempdir
         file = joinpath(tempdir, "hello.txt")


### PR DESCRIPTION
Adds a GitHub Actions test token to verify gist artifact uploads and creates corresponding unit tests.

Co-authored-by: GitHub Copilot <noreply@github.com>
